### PR TITLE
Tweak to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import Truncate from 'react-truncate';
 class Foo extends Component {
     render() {
         return (
-            <Truncate lines={3} ellipsis={<span>... <a href='#'>Read more</a></span>}>
+            <Truncate lines={3} ellipsis={<span>... <a href='/link/to/article'>Read more</a></span>}>
                 {longText}
             </Truncate>
         );


### PR DESCRIPTION
Using # as href target is misleading, as it might imply there is additional behavior (like showing the entire text when someone clicks on 'read more').