### PR TITLE
Force Rerendering When New Children Are Passed In

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -40,6 +40,13 @@ export default class Truncate extends Component {
         this.onResize();
     }
 
+    componentDidUpdate(prevProps) {
+        // Render was based on outdated refs and needs to be rerun
+        if (this.props.children !== prevProps.children) {
+            this.forceUpdate();
+        }
+    }
+
     componentWillUnmount() {
         window.removeEventListener('resize', this.onResize);
     }

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -149,6 +149,36 @@ describe('<Truncate />', () => {
                 the … read more
             `);
         });
+
+        it('should update content when new children are passed in', () => {
+            let container = document.createElement('div');
+
+            let component = render(
+                <div>
+                    <Truncate lines={1}>
+                        Some old content
+                    </Truncate>
+                </div>,
+                container
+            );
+
+            expect(component, 'to display text', `
+                Some old cont…
+            `);
+
+            render(
+                <div>
+                    <Truncate lines={1}>
+                        Some new content
+                    </Truncate>
+                </div>,
+                container
+            );
+
+            expect(component, 'to display text', `
+                Some new con…
+            `);
+        });
     });
 
     it('should recalculate when resizing the window', () => {


### PR DESCRIPTION
Lines depend on the render output of the children, but are calculated before refs update, so that the old content would be rendered.