### PR TITLE
Possible workaround for Issue#8

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -125,6 +125,7 @@ export default class Truncate extends Component {
             },
             props: {
                 lines: numLines,
+                ellipsisTextOverride,
                 ellipsis
             },
             state: {
@@ -133,6 +134,11 @@ export default class Truncate extends Component {
             measureWidth,
             onTruncate
         } = this;
+
+        // do we have an ellipsisTextOverride?  if so, use that
+        if (ellipsisTextOverride) {
+          ellipsisText = ellipsisTextOverride;
+        }
 
         let lines = [];
         let textWords = text.split(' ');
@@ -161,7 +167,7 @@ export default class Truncate extends Component {
 
                     let testLine = textRest.slice(0, middle + 1);
 
-                    if (measureWidth(testLine + ellipsisText) <= targetWidth) {
+                    if (measureWidth(testLine + ellipsisText ) <= targetWidth) {
                         lower = middle + 1;
                     } else {
                         upper = middle - 1;


### PR DESCRIPTION
-This is just a suggestion for how to get around calculating ellipsis text if the content is not a string, but is a constant length (specifically icon of fixedwidth)
-Would work in resusable components (i.e. we are trying to have an info-icon that triggers a modal when clicked)
-You could pass in the prop on the component level to override the ellipsisText default (only use when you need to). Prop passed in would need to be set # of characters, so not great for patterns w/ lots of non-string ellipsis variation