### PR TITLE
Fix Ellipsis Offset Width

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -32,7 +32,10 @@ export default class Truncate extends Component {
 
     componentDidMount() {
         // Node not needed in document tree to read its content
-        this.refs.raw.parentNode.removeChild(this.refs.raw);
+        this.refs.text.parentNode.removeChild(this.refs.text);
+
+        // Keep node in document body to read .offsetWidth
+        document.body.appendChild(this.refs.ellipsis);
 
         let canvas = document.createElement('canvas');
         this.canvas = canvas.getContext('2d');
@@ -50,6 +53,8 @@ export default class Truncate extends Component {
     }
 
     componentWillUnmount() {
+        document.body.removeChild(this.refs.ellipsis);
+
         window.removeEventListener('resize', this.onResize);
 
         cancelAnimationFrame(this.timeout);
@@ -252,17 +257,20 @@ export default class Truncate extends Component {
         return (
             <span {...spanProps} ref='target'>
                 {text}
-                <span ref='raw' style={this.styles.raw}>
-                    <span ref='text'>{children}</span>
-                    <span ref='ellipsis'>{ellipsis}</span>
+                <span ref='text'>{children}</span>
+                <span ref='ellipsis' style={this.styles.ellipsis}>
+                    {ellipsis}
                 </span>
             </span>
         );
     }
 
     styles = {
-        raw: {
-            display: 'none'
+        ellipsis: {
+            position: 'fixed',
+            visibility: 'hidden',
+            top: 0,
+            left: 0
         }
     };
 };

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -113,14 +113,15 @@ export default class Truncate extends Component {
         return this.canvas.measureText(text).width;
     }
 
+    ellipsisWidth(node) {
+        return node.offsetWidth;
+    }
+
     getLines() {
         let {
             refs: {
                 text: {
                     textContent: text
-                },
-                ellipsis: {
-                    textContent: ellipsisText
                 }
             },
             props: {
@@ -137,6 +138,7 @@ export default class Truncate extends Component {
         let lines = [];
         let textWords = text.split(' ');
         let didTruncate = true;
+        let ellipsisWidth = this.ellipsisWidth(this.refs.ellipsis);
 
         for (let line = 1; line <= numLines; line++) {
             let resultLine = textWords.join(' ');
@@ -161,7 +163,7 @@ export default class Truncate extends Component {
 
                     let testLine = textRest.slice(0, middle + 1);
 
-                    if (measureWidth(testLine + ellipsisText) <= targetWidth) {
+                    if (measureWidth(testLine) + ellipsisWidth <= targetWidth) {
                         lower = middle + 1;
                     } else {
                         upper = middle - 1;

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -88,10 +88,22 @@ describe('<Truncate />', () => {
                 sinon.stub(global.window.HTMLDivElement.prototype,
                     'getBoundingClientRect', () => ({ width: 85 })
                 );
+
+                // Approximate .offsetWidth with context.measureText
+                sinon.stub(Truncate.prototype,
+                    'ellipsisWidth', node => {
+                        let canvas = document.createElement('canvas');
+                        let context = canvas.getContext('2d');
+
+                        return context.measureText(node.textContent).width;
+                    }
+                );
             });
 
             after(() => {
                 global.window.HTMLDivElement.prototype.getBoundingClientRect.restore();
+
+                Truncate.prototype.ellipsisWidth.restore();
             });
 
             it('should truncate text', () => {

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -349,4 +349,18 @@ describe('<Truncate />', () => {
             }
         });
     });
+
+    describe('ellipsisWidth', () => {
+        it('should equal node.offsetWidth', () => {
+            let offsetWidth = () => 123;
+
+            let node = {};
+
+            Object.defineProperty(node, 'offsetWidth', {
+                get: offsetWidth
+            });
+
+            expect(Truncate.prototype.ellipsisWidth(node), 'to be', 123);
+        });
+    });
 });


### PR DESCRIPTION
Context: https://github.com/One-com/react-truncate/pull/13

This fix enables using any element as ellipsis, containing for example icons, versus previously only text-based content.