### PR TITLE
Prevent double-rendering on server-side

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -276,12 +276,13 @@ export default class Truncate extends Component {
             onTruncate
         } = this;
 
-        let text = children;
+        let text;
 
         if (typeof window !== 'undefined') {
             if (target && targetWidth && lines > 0) {
                 text = getLines().map(renderLine);
             } else {
+                text = children;
                 onTruncate(false);
             }
         }


### PR DESCRIPTION
`let text = children;` caused the text passed into the component to be rendered twice on the server-side for us, which is related to the following bit inside `render()`:

```
{text}
<span ref="text">{children}</span>
```

With my change it seems to work fine on both, client and server.

The "in a server environment" case of the tests was still green for me. There were a few other failures though, which seemed to be unrelated to my changes (they were red even without my commit).