### PR TITLE
Fix Duplicate Text When Rendering On Server

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -276,10 +276,12 @@ export default class Truncate extends Component {
             onTruncate
         } = this;
 
-        let text = children;
+        let text;
 
-        if (typeof window !== 'undefined') {
-            if (target && targetWidth && lines > 0) {
+        const mounted = !!(target && targetWidth);
+
+        if (typeof window !== 'undefined' && mounted) {
+            if (lines > 0) {
                 text = getLines().map(renderLine);
             } else {
                 onTruncate(false);

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -50,7 +50,7 @@ describe('<Truncate />', () => {
 
     describe('in a server environment', () => {
         it('should render initial static markup', () => {
-            renderToString(
+            const markup = renderToString(
                 <Truncate
                     lines={2}
                     ellipsis='…'
@@ -58,6 +58,12 @@ describe('<Truncate />', () => {
                 >
                     Some text inside of here
                 </Truncate>
+            );
+
+            expect(
+                markup.match(/Some text inside of here/g).length,
+                'to be',
+                1
             );
         });
     });


### PR DESCRIPTION
#20 @codejet, attributed you for the [commit](https://github.com/One-com/react-truncate/commit/eee38878ac3b25505ed50dbf7834dabcd3e29daa), but changed it slightly so it doesn't cause a client/server mismatch when the app hydrates on the client.