### PR TITLE
Account for letter-spacing and word-spacing css

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -141,7 +141,9 @@ export default class Truncate extends Component {
             style['font-weight'],
             style['font-style'],
             style['font-size'],
-            style['font-family']
+            style['font-family'],
+            style['letter-spacing'],
+            style['word-spacing']
         ].join(' ');
 
         canvas.font = font;


### PR DESCRIPTION
This fixes incorrect wrapping and truncating when the css uses letter-spacing and/or word-spacing properties.