### PR TITLE
Make Test Suite work across Operating Systems

### DIFF
--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -276,6 +276,18 @@ describe('<Truncate />', () => {
                 `);
             });
 
+            it('should render without an error when the last line is exactly as wide as the container', () => {
+                const render = () => renderIntoDocument(
+                    <div>
+                        <Truncate lines={2}>
+                            {new Array(numCharacters).fill('a').join()}
+                        </Truncate>
+                    </div>
+                );
+
+                expect(render, 'not to throw');
+            });
+
             describe('onTruncate', () => {
                 describe('with Truncate.prototype.onTruncate mocked out', () => {
                     before(() => {
@@ -357,39 +369,6 @@ describe('<Truncate />', () => {
                     expect(handleTruncate, 'was called');
                 });
             });
-        });
-
-        it('should render without an error when the last line is exactly as wide as the container', () => {
-            const text = 'Foo bar - end of text';
-
-            sinon.stub(global.window.HTMLDivElement.prototype,
-                'getBoundingClientRect', () => ({
-                    width: measureWidth(text)
-                })
-            );
-
-            // Approximate .offsetWidth
-            sinon.stub(Truncate.prototype,
-                'ellipsisWidth', node => {
-                    return measureWidth(text);
-                }
-            );
-
-            try {
-                const render = () => renderIntoDocument(
-                    <div>
-                        <Truncate lines={2}>
-                            Foo bar - end of text
-                        </Truncate>
-                    </div>
-                );
-
-                expect(render, 'not to throw');
-            } finally {
-                global.window.HTMLDivElement.prototype.getBoundingClientRect.restore();
-
-                Truncate.prototype.ellipsisWidth.restore();
-            }
         });
 
         it('should recalculate when resizing the window', () => {

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -127,6 +127,12 @@ describe('<Truncate />', () => {
                     'getBoundingClientRect', () => ({ width })
                 );
 
+                sinon.stub(Truncate.prototype,
+                    'measureWidth', text => {
+                        return measureWidth(text);
+                    }
+                );
+
                 // Approximate .offsetWidth
                 sinon.stub(Truncate.prototype,
                     'ellipsisWidth', node => {
@@ -138,6 +144,7 @@ describe('<Truncate />', () => {
             after(() => {
                 global.window.HTMLDivElement.prototype.getBoundingClientRect.restore();
 
+                Truncate.prototype.measureWidth.restore();
                 Truncate.prototype.ellipsisWidth.restore();
             });
 

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -111,8 +111,8 @@ describe('<Truncate />', () => {
             }
         });
 
-        // Mock out a box that's 14 characters wide
-        const numCharacters = 14;
+        // Mock out a box that's 16 characters wide
+        const numCharacters = 16;
         const width = numCharacters * characterWidth;
 
         describe(`with a box of ${width}px mocked out`, () => {
@@ -160,7 +160,7 @@ describe('<Truncate />', () => {
 
                 expect(component, 'to display text', `
                     This text should
-                    stop after here …
+                    stop after here…
                 `);
             });
 
@@ -249,7 +249,7 @@ describe('<Truncate />', () => {
 
                 expect(component, 'to display text', `
                     I'm curious what
-                    the… read more
+                    the n… read more
                 `);
             });
 
@@ -259,27 +259,27 @@ describe('<Truncate />', () => {
                 const component = render(
                     <div>
                         <Truncate lines={1}>
-                            Some old content
+                            Some old content here
                         </Truncate>
                     </div>,
                     container
                 );
 
                 expect(component, 'to display text', `
-                    Some old conte…
+                    Some old conten…
                 `);
 
                 render(
                     <div>
                         <Truncate lines={1}>
-                            Some new content
+                            Some new content here
                         </Truncate>
                     </div>,
                     container
                 );
 
                 expect(component, 'to display text', `
-                    Some new cont…
+                    Some new conten…
                 `);
             });
 
@@ -319,8 +319,9 @@ describe('<Truncate />', () => {
 
                         renderIntoBox(
                             <Truncate onTruncate={handleTruncate}>
-                                This is some text
-                                that got truncated
+                                Some text over
+                                here that got
+                                truncated
                             </Truncate>
                         );
 
@@ -333,8 +334,8 @@ describe('<Truncate />', () => {
 
                             renderIntoBox(
                                 <Truncate lines={false} onTruncate={handleTruncate}>
-                                    This is some text
-                                    that did not get
+                                    Some text over
+                                    here that is not
                                     truncated
                                 </Truncate>
                             );
@@ -347,8 +348,8 @@ describe('<Truncate />', () => {
 
                             renderIntoBox(
                                 <Truncate lines={3} onTruncate={handleTruncate}>
-                                    This is some text
-                                    that did not get
+                                    Some text over
+                                    here that is not
                                     truncated
                                 </Truncate>
                             );


### PR DESCRIPTION
Context: #33

---

Approximate text width by multiplying amount of characters instead of relying on `Canvas.measureText` for that. This means that the calculation is no longer dependent on how the OS renders fonts and therefore makes the test suite simpler, and portable across OS environments.

@eric-adstage, could you run the tests for this branch locally to see if I missed anything?