### PR TITLE
Support for Firefox versions older than 45

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -83,7 +83,7 @@ export default class Truncate extends Component {
     // Shim innerText to consistently break lines at <br/> but not at \n
     innerText(node) {
         const div = document.createElement('div');
-        const contentKey = 'innerText' in HTMLElement.prototype ? 'innerText' : 'textContent';
+        const contentKey = 'innerText' in div ? 'innerText' : 'textContent';
 
         div.innerHTML = node.innerHTML.replace(/\r\n|\r|\n/g, ' ');
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -83,7 +83,7 @@ export default class Truncate extends Component {
     // Shim innerText to consistently break lines at <br/> but not at \n
     innerText(node) {
         const div = document.createElement('div');
-        const contentKey = 'innerText' in document.createElement('div') ? 'innerText' : 'textContent';
+        const contentKey = 'innerText' in HTMLElement.prototype ? 'innerText' : 'textContent';
 
         div.innerHTML = node.innerHTML.replace(/\r\n|\r|\n/g, ' ');
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -82,16 +82,18 @@ export default class Truncate extends Component {
     // Shim innerText to consistently break lines at <br/> but not at \n
     innerText(node) {
         const div = document.createElement('div');
+        const contentKey = 'innerText' in document.createElement('div') ? 'innerText' : 'textContent';
+
         div.innerHTML = node.innerHTML.replace(/\r\n|\r|\n/g, ' ');
 
-        let text = div.innerText;
+        let text = div[contentKey];
 
         const test = document.createElement('div');
         test.innerHTML = 'foo<br/>bar';
 
-        if (test.innerText.replace(/\r\n|\r/g, '\n') !== 'foo\nbar') {
+        if (test[contentKey].replace(/\r\n|\r/g, '\n') !== 'foo\nbar') {
             div.innerHTML = div.innerHTML.replace(/<br.*?[\/]?>/gi, '\n');
-            text = div.innerText;
+            text = div[contentKey];
         }
 
         return text;

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -83,7 +83,7 @@ export default class Truncate extends Component {
     // Shim innerText to consistently break lines at <br/> but not at \n
     innerText(node) {
         const div = document.createElement('div');
-        const contentKey = 'innerText' in div ? 'innerText' : 'textContent';
+        const contentKey = 'innerText' in window.HTMLElement.prototype ? 'innerText' : 'textContent';
 
         div.innerHTML = node.innerHTML.replace(/\r\n|\r|\n/g, ' ');
 


### PR DESCRIPTION
Older versions of Firefox don’t support ```innerText```, I've added ```textContent``` method as backup. Also this method (```textContent```) works faster, if it matches library needs you can replace innerText with textContent, check [reference](http://perfectionkills.com/the-poor-misunderstood-innerText/).
Thanks.