### PR TITLE
Fix the read more example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ class ReadMore extends Component {
     }
 
     handleTruncate(truncated) {
-        this.setState({
-            truncated
-        });
+        if(this.state.truncated !== truncated) {
+            this.setState({
+                truncated
+            });
+        }
     }
 
     toggleLines(event) {


### PR DESCRIPTION
The current read more example is broken as it creates an endless loop by calling setState on every render.