### PR TITLE
Fix PropTypes deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Hint: (Generally with React) if you want to preserve newlines from plain text, y
 
 ## Integrated example for toggling "read more" text
 ```js
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Hint: (Generally with React) if you want to preserve newlines from plain text, y
 ## Integrated example for toggling "read more" text
 ```js
 import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
 
 class ReadMore extends Component {

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "unexpected-dom": "^3.1.1",
     "unexpected-react": "^3.4.0",
     "unexpected-sinon": "^10.7.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.6"
   }
 }

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Truncate extends Component {
     static propTypes = {


### PR DESCRIPTION
PropTypes are becoming deprecated in React v16.0.0 and are hitting warnings in React v15.5.0, [migration guide](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes).  
