### PR TITLE
added parentNode padding to targetWidth calculation

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -152,10 +152,9 @@ export default class Truncate extends Component {
         const parentPadding = (
                 ((parseInt(parentStyle['padding-left'])!=NaN)?parseInt(parentStyle['padding-left']):0)
                 + ((parseInt(parentStyle['padding-right'])!=NaN)?parseInt(parentStyle['padding-right']):0));
-        targetWidth-=parentPadding
 
         this.setState({
-            targetWidth
+            (targetWidth - parentPadding)
         }, callback);
     }
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -152,9 +152,10 @@ export default class Truncate extends Component {
         const parentPadding = (
                 ((parseInt(parentStyle['padding-left'])!=NaN)?parseInt(parentStyle['padding-left']):0)
                 + ((parseInt(parentStyle['padding-right'])!=NaN)?parseInt(parentStyle['padding-right']):0));
+        targetWidth-=parentPadding
 
         this.setState({
-            (targetWidth - parentPadding)
+            targetWidth
         }, callback);
     }
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -147,8 +147,14 @@ export default class Truncate extends Component {
 
         canvas.font = font;
 
+        const parentStyle = window.getComputedStyle(target.parentNode);
+
+        const parentPadding = (
+                ((parseInt(parentStyle['padding-left'])!=NaN)?parseInt(parentStyle['padding-left']):0)
+                + ((parseInt(parentStyle['padding-right'])!=NaN)?parseInt(parentStyle['padding-right']):0));
+
         this.setState({
-            targetWidth
+            (targetWidth - parentPadding)
         }, callback);
     }
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -128,7 +128,7 @@ export default class Truncate extends Component {
             return;
         }
 
-        const targetWidth = target.parentNode.getBoundingClientRect().width;
+        let targetWidth = target.parentNode.getBoundingClientRect().width;
 
         // Delay calculation until parent node is inserted to the document
         // Mounting order in React is ChildComponent, ParentComponent
@@ -153,8 +153,10 @@ export default class Truncate extends Component {
                 ((parseInt(parentStyle['padding-left'])!=NaN)?parseInt(parentStyle['padding-left']):0)
                 + ((parseInt(parentStyle['padding-right'])!=NaN)?parseInt(parentStyle['padding-right']):0));
 
+        targetWidth-=parentPadding;
+
         this.setState({
-            (targetWidth - parentPadding)
+            targetWidth
         }, callback);
     }
 


### PR DESCRIPTION
In case the truncate text's parent has paddingLeft or paddingRight or both, truncate needs to consider that in targetWidth calculation.