### PR TITLE
Add option to trim whitespace before ellipsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Hint: (Generally with React) if you want to preserve newlines from plain text, y
 | ellipsis | string, React node | '…' | An ellipsis that is added to the end of the text in case it is truncated. | `'...'`, `<span>...</span>`, `<span>... <a href='#' onClick={someHandler}>Read more</a></span>`, `[<span key='some'>Some</span>, <span key='siblings'>siblings<span>]`
 | children | string, React node | | The text to be truncated. Anything that can be evaluated as text. | `'Some text'`, `<p>Some paragraph <a/>with other text-based inline elements<a></p>`, `<span>Some</span><span>siblings</span>` |
 | onTruncate | function | | Gets invoked on each render. Gets called with `true` when text got truncated and ellipsis was injected, and with `false` otherwise. | `isTruncated => isTruncated !== this.state.isTruncated && this.setState({ isTruncated })` |
+| trimWhitespace | boolean | false | If `true`, whitespace will be removed from before the ellipsis (e.g. `words ...` will become `words...` instead) | `<Truncate trimWhitespace>{longText}</Truncate>` |
 
 ## Known issues
 - Text exceeding horizontal boundaries when "viewport" meta tag is not set accordingly for mobile devices (font boosting leads to wrong calculations). See [issue](https://github.com/One-com/react-truncate/issues/4#issuecomment-226703499)

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -9,13 +9,15 @@ export default class Truncate extends Component {
             PropTypes.oneOf([false]),
             PropTypes.number
         ]),
+        trimWhitespace: PropTypes.bool,
         onTruncate: PropTypes.func
     };
 
     static defaultProps = {
         children: '',
         ellipsis: '…',
-        lines: 1
+        lines: 1,
+        trimWhitespace: false
     };
 
     state = {};
@@ -167,19 +169,25 @@ export default class Truncate extends Component {
         return node.offsetWidth;
     }
 
+    trimRight(text) {
+        return text.replace(/\s+$/, '');
+    }
+
     getLines() {
         const {
             elements,
             props: {
                 lines: numLines,
-                ellipsis
+                ellipsis,
+                trimWhitespace
             },
             state: {
                 targetWidth
             },
             innerText,
             measureWidth,
-            onTruncate
+            onTruncate,
+            trimRight
         } = this;
 
         const lines = [];
@@ -230,7 +238,20 @@ export default class Truncate extends Component {
                     }
                 }
 
-                resultLine = <span>{textRest.slice(0, lower)}{ellipsis}</span>;
+                let lastLineText = textRest.slice(0, lower);
+
+                if (trimWhitespace) {
+                    lastLineText = trimRight(lastLineText);
+
+                    // remove blank lines from the end of text
+                    while (!lastLineText.length && lines.length) {
+                        const prevLine = lines.pop();
+
+                        lastLineText = trimRight(prevLine);
+                    }
+                }
+
+                resultLine = <span>{lastLineText}{ellipsis}</span>;
             } else {
                 // Binary search determining when the line breaks
                 let lower = 0;

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -324,6 +324,38 @@ describe('<Truncate />', () => {
                         contains…
                     `);
                 });
+
+                it('should render empty text without an error', () => {
+                    const container = document.createElement('div');
+
+                    const componentA = render(
+                        <div>
+                            <Truncate lines={1} trimWhitespace />
+                        </div>,
+                        container
+                    );
+
+                    expect(componentA, 'to display text', '');
+                });
+
+                it('should truncate whitespace only text without an error', () => {
+                    const container = document.createElement('div');
+
+                    const componentA = render(
+                        <div>
+                            <Truncate lines={1} trimWhitespace>
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                            </Truncate>
+                        </div>,
+                        container
+                    );
+
+                    expect(componentA, 'to display text', '…');
+                });
             });
 
             describe('onTruncate', () => {
@@ -520,6 +552,19 @@ describe('<Truncate />', () => {
             });
 
             expect(Truncate.prototype.ellipsisWidth(node), 'to be', 123);
+        });
+    });
+
+    describe('trimRight', () => {
+        it('should remove whitespace from the end of text', () => {
+            expect(Truncate.prototype.trimRight('some spaces here  '), 'to be', 'some spaces here');
+            expect(Truncate.prototype.trimRight('some other whitespace here  \r\n'), 'to be', 'some other whitespace here');
+            expect(Truncate.prototype.trimRight('\n  '), 'to be', '');
+        });
+
+        it('should leave other text unchanged', () => {
+            expect(Truncate.prototype.trimRight('  whitespace on the left'), 'to be', '  whitespace on the left');
+            expect(Truncate.prototype.trimRight(' just a \n lot of text really'), 'to be', ' just a \n lot of text really');
         });
     });
 });

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -293,6 +293,39 @@ describe('<Truncate />', () => {
                 expect(render, 'not to throw');
             });
 
+            describe('with trimWhitespace', () => {
+                it('should remove whitespace from before the ellipsis', () => {
+                    const container = document.createElement('div');
+
+                    const componentA = render(
+                        <div>
+                            <Truncate lines={1} trimWhitespace>
+                                Some old stuff here
+                            </Truncate>
+                        </div>,
+                        container
+                    );
+
+                    expect(componentA, 'to display text', `
+                        Some old stuff…
+                    `);
+
+                    const componentB = renderIntoBox(
+                        <Truncate lines={3} trimWhitespace>
+                            This text
+                            contains<br />
+                            <br />
+                            newlines
+                        </Truncate>
+                    );
+
+                    expect(componentB, 'to display text', `
+                        This text
+                        contains…
+                    `);
+                });
+            });
+
             describe('onTruncate', () => {
                 describe('with Truncate.prototype.onTruncate mocked out', () => {
                     before(() => {


### PR DESCRIPTION
In many cases whitespace before the ellipsis is unsightly or against styling practices, so it is useful 
to have an extra boolean prop`trimWhitespace` to trim this excess whitespace when desired.

For example, the text below would show as `what...` rather than `what ...` with the `trimWhitespace` prop set.

<img width="97" alt="screen shot 2017-10-23 at 16 36 16" src="https://user-images.githubusercontent.com/5824792/31898258-9fe108e2-b810-11e7-91bc-a0a2d7556620.png">
