### PR TITLE
Do not add ellipsis span to the body, keep it in target element

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -46,9 +46,6 @@ export default class Truncate extends Component {
         const canvas = document.createElement('canvas');
         this.canvasContext = canvas.getContext('2d');
 
-        // Keep node in document body to read .offsetWidth
-        document.body.appendChild(ellipsis);
-
         calcTargetWidth(() => {
             // Node not needed in document tree to read its content
             if (text) {

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -36,8 +36,7 @@ export default class Truncate extends Component {
     componentDidMount() {
         const {
             elements: {
-                text,
-                ellipsis
+                text
             },
             calcTargetWidth,
             onResize

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -264,7 +264,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some old conten…
+                    Some old conten……
                 `);
 
                 render(
@@ -277,7 +277,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some new conten…
+                    Some new conten……
                 `);
             });
 


### PR DESCRIPTION
Should fix this issue: https://github.com/One-com/react-truncate/issues/77

Correct me if I am wrong (maybe I am missing something) but I suspect that the fact that this component is working is actually just a coincidence. Most people probably use the same font and font size both in body and in truncated text (in this scenario everything should be ok). However changing the font size is enough to break the component.

I've also made kind of weird change to unit test: ellipsis symbol is now duplicated (the second copy is hidden ellipsis span). Not sure how to make it more obvious what's happening there...
