### PR TITLE
Support for text without spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Hint: (Generally with React) if you want to preserve newlines from plain text, y
 | children | string, React node | | The text to be truncated. Anything that can be evaluated as text. | `'Some text'`, `<p>Some paragraph <a/>with other text-based inline elements<a></p>`, `<span>Some</span><span>siblings</span>` |
 | onTruncate | function | | Gets invoked on each render. Gets called with `true` when text got truncated and ellipsis was injected, and with `false` otherwise. | `isTruncated => isTruncated !== this.state.isTruncated && this.setState({ isTruncated })` |
 | trimWhitespace | boolean | false | If `true`, whitespace will be removed from before the ellipsis (e.g. `words ...` will become `words...` instead) | `<Truncate trimWhitespace>{longText}</Truncate>` |
-| breakWords | boolean | false | If `true`, lines will break at any place, not only on spaces (useful for example for truncating multiline URLs). | `<Truncate breakWords lines={3}>{longText}</Truncate>` |
+| breakAll | boolean | false | If `true`, lines will break at any place, not only on spaces (useful for example for truncating multiline URLs). | `<Truncate breakAll lines={3}>{longText}</Truncate>` |
 
 ## Known issues
 - Text exceeding horizontal boundaries when "viewport" meta tag is not set accordingly for mobile devices (font boosting leads to wrong calculations). See [issue](https://github.com/One-com/react-truncate/issues/4#issuecomment-226703499)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Hint: (Generally with React) if you want to preserve newlines from plain text, y
 | children | string, React node | | The text to be truncated. Anything that can be evaluated as text. | `'Some text'`, `<p>Some paragraph <a/>with other text-based inline elements<a></p>`, `<span>Some</span><span>siblings</span>` |
 | onTruncate | function | | Gets invoked on each render. Gets called with `true` when text got truncated and ellipsis was injected, and with `false` otherwise. | `isTruncated => isTruncated !== this.state.isTruncated && this.setState({ isTruncated })` |
 | trimWhitespace | boolean | false | If `true`, whitespace will be removed from before the ellipsis (e.g. `words ...` will become `words...` instead) | `<Truncate trimWhitespace>{longText}</Truncate>` |
+| breakWords | boolean | false | If `true`, lines will break at any place, not only on spaces (useful for example for truncating multiline URLs). | `<Truncate breakWords lines={3}>{longText}</Truncate>` |
 
 ## Known issues
 - Text exceeding horizontal boundaries when "viewport" meta tag is not set accordingly for mobile devices (font boosting leads to wrong calculations). See [issue](https://github.com/One-com/react-truncate/issues/4#issuecomment-226703499)

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -191,7 +191,8 @@ export default class Truncate extends Component {
 
         const lines = [];
         const text = innerText(elements.text);
-        const textLines = text.split('\n').map(line => line.split(breakWords ? '' : ' '));
+        const wordSeparator = breakWords ? '' : ' ';
+        const textLines = text.split('\n').map(line => line.split(wordSeparator));
         let didTruncate = true;
         const ellipsisWidth = this.ellipsisWidth(this.elements.ellipsis);
 
@@ -206,7 +207,7 @@ export default class Truncate extends Component {
                 continue;
             }
 
-            let resultLine = textWords.join(breakWords ? '' : ' ');
+            let resultLine = textWords.join(wordSeparator);
 
             if (measureWidth(resultLine) <= targetWidth) {
                 if (textLines.length === 1) {
@@ -220,7 +221,7 @@ export default class Truncate extends Component {
 
             if (line === numLines) {
                 // Binary search determining the longest possible line inluding truncate string
-                const textRest = textWords.join(breakWords ? '' : ' ');
+                const textRest = textWords.join(wordSeparator);
 
                 let lower = 0;
                 let upper = textRest.length - 1;
@@ -259,7 +260,7 @@ export default class Truncate extends Component {
                 while (lower <= upper) {
                     const middle = Math.floor((lower + upper) / 2);
 
-                    const testLine = textWords.slice(0, middle + 1).join(breakWords ? '' : ' ');
+                    const testLine = textWords.slice(0, middle + 1).join(wordSeparator);
 
                     if (measureWidth(testLine) <= targetWidth) {
                         lower = middle + 1;
@@ -275,7 +276,7 @@ export default class Truncate extends Component {
                     continue;
                 }
 
-                resultLine = textWords.slice(0, lower).join(breakWords ? '' : ' ');
+                resultLine = textWords.slice(0, lower).join(wordSeparator);
                 textLines[0].splice(0, lower);
             }
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -10,7 +10,7 @@ export default class Truncate extends Component {
             PropTypes.number
         ]),
         trimWhitespace: PropTypes.bool,
-        breakWords: PropTypes.bool,
+        breakAll: PropTypes.bool,
         onTruncate: PropTypes.func
     };
 
@@ -19,7 +19,7 @@ export default class Truncate extends Component {
         ellipsis: '…',
         lines: 1,
         trimWhitespace: false,
-        breakWords: false
+        breakAll: false
     };
 
     state = {};
@@ -178,7 +178,7 @@ export default class Truncate extends Component {
                 lines: numLines,
                 ellipsis,
                 trimWhitespace,
-                breakWords
+                breakAll
             },
             state: {
                 targetWidth
@@ -191,7 +191,7 @@ export default class Truncate extends Component {
 
         const lines = [];
         const text = innerText(elements.text);
-        const wordSeparator = breakWords ? '' : ' ';
+        const wordSeparator = breakAll ? '' : ' ';
         const textLines = text.split('\n').map(line => line.split(wordSeparator));
         let didTruncate = true;
         const ellipsisWidth = this.ellipsisWidth(this.elements.ellipsis);
@@ -340,7 +340,7 @@ export default class Truncate extends Component {
 
         delete spanProps.onTruncate;
         delete spanProps.trimWhitespace;
-        delete spanProps.breakWords;
+        delete spanProps.breakAll;
 
         return (
             <span {...spanProps} ref={(targetEl) => { this.elements.target = targetEl; }}>

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -46,9 +46,6 @@ export default class Truncate extends Component {
         const canvas = document.createElement('canvas');
         this.canvasContext = canvas.getContext('2d');
 
-        // Keep node in document body to read .offsetWidth
-        document.body.appendChild(ellipsis);
-
         calcTargetWidth(() => {
             // Node not needed in document tree to read its content
             if (text) {

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -10,6 +10,7 @@ export default class Truncate extends Component {
             PropTypes.number
         ]),
         trimWhitespace: PropTypes.bool,
+        breakWords: PropTypes.bool,
         onTruncate: PropTypes.func
     };
 
@@ -17,7 +18,8 @@ export default class Truncate extends Component {
         children: '',
         ellipsis: '…',
         lines: 1,
-        trimWhitespace: false
+        trimWhitespace: false,
+        breakWords: false
     };
 
     state = {};
@@ -175,7 +177,8 @@ export default class Truncate extends Component {
             props: {
                 lines: numLines,
                 ellipsis,
-                trimWhitespace
+                trimWhitespace,
+                breakWords
             },
             state: {
                 targetWidth
@@ -188,7 +191,7 @@ export default class Truncate extends Component {
 
         const lines = [];
         const text = innerText(elements.text);
-        const textLines = text.split('\n').map(line => line.split(' '));
+        const textLines = text.split('\n').map(line => line.split(breakWords ? '' : ' '));
         let didTruncate = true;
         const ellipsisWidth = this.ellipsisWidth(this.elements.ellipsis);
 
@@ -203,7 +206,7 @@ export default class Truncate extends Component {
                 continue;
             }
 
-            let resultLine = textWords.join(' ');
+            let resultLine = textWords.join(breakWords ? '' : ' ');
 
             if (measureWidth(resultLine) <= targetWidth) {
                 if (textLines.length === 1) {
@@ -217,7 +220,7 @@ export default class Truncate extends Component {
 
             if (line === numLines) {
                 // Binary search determining the longest possible line inluding truncate string
-                const textRest = textWords.join(' ');
+                const textRest = textWords.join(breakWords ? '' : ' ');
 
                 let lower = 0;
                 let upper = textRest.length - 1;
@@ -256,7 +259,7 @@ export default class Truncate extends Component {
                 while (lower <= upper) {
                     const middle = Math.floor((lower + upper) / 2);
 
-                    const testLine = textWords.slice(0, middle + 1).join(' ');
+                    const testLine = textWords.slice(0, middle + 1).join(breakWords ? '' : ' ');
 
                     if (measureWidth(testLine) <= targetWidth) {
                         lower = middle + 1;
@@ -272,7 +275,7 @@ export default class Truncate extends Component {
                     continue;
                 }
 
-                resultLine = textWords.slice(0, lower).join(' ');
+                resultLine = textWords.slice(0, lower).join(breakWords ? '' : ' ');
                 textLines[0].splice(0, lower);
             }
 
@@ -336,6 +339,7 @@ export default class Truncate extends Component {
 
         delete spanProps.onTruncate;
         delete spanProps.trimWhitespace;
+        delete spanProps.breakWords;
 
         return (
             <span {...spanProps} ref={(targetEl) => { this.elements.target = targetEl; }}>

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -36,8 +36,7 @@ export default class Truncate extends Component {
     componentDidMount() {
         const {
             elements: {
-                text,
-                ellipsis
+                text
             },
             calcTargetWidth,
             onResize

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -264,7 +264,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some old conten…
+                    Some old conten……
                 `);
 
                 render(
@@ -277,7 +277,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some new conten…
+                    Some new conten……
                 `);
             });
 

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -268,7 +268,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some old conten……
+                    Some old conten…
                 `);
 
                 render(
@@ -281,7 +281,7 @@ describe('<Truncate />', () => {
                 );
 
                 expect(component, 'to display text', `
-                    Some new conten……
+                    Some new conten…
                 `);
             });
 


### PR DESCRIPTION
This should enable multiline truncating of non-typical text that does not contain spaces (eg URLs) and hopefully also resolve #82.

New property `breakAll` added (default: `false`). 

When set to `true`, truncated text will behave as if css rule `word-break: break-all` was applied to the parent block.

Result looks like this:

![image](https://user-images.githubusercontent.com/5717615/36210634-37bf43da-119f-11e8-9a8e-589fb4ecee9d.png)

