### PR TITLE
Fixing jsdom exceptions 'Not implemented: HTMLCanvasElement.prototype.getContext'

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -80,7 +80,7 @@ export default class Truncate extends Component {
             timeout
         } = this;
 
-        ellipsis.parentNode.removeChild(ellipsis);
+        if (ellipsis) ellipsis.parentNode.removeChild(ellipsis);
 
         window.removeEventListener('resize', onResize);
 


### PR DESCRIPTION
Adding null or undefined condition for ellipsis in order to avoid "Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)" during tests
see also here:
https://github.com/hustcc/jest-canvas-mock/issues/2