### PR TITLE
Bugfix: Fix font variable ordering for proper font-weight calculation in IE11

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -157,8 +157,8 @@ export default class Truncate extends Component {
         const style = window.getComputedStyle(target);
 
         const font = [
-            style['font-weight'],
             style['font-style'],
+            style['font-weight'],
             style['font-size'],
             style['font-family']
         ].join(' ');


### PR DESCRIPTION
Fixes #127 and possibly #138.

The character calculation is off in IE11 because font-weight is not properly applied as IE11 requires strict adherence to the font string docs with font-weight after font-style (https://developer.mozilla.org/en-US/docs/Web/CSS/font#formal_syntax).

So in IE11  'normal 700 28pt Arial' (font-weight after style) results in bolded text, same as bolded '700 28pt Arial' .
<img width="450" alt="Screen Shot 2021-09-23 at 10 55 51 AM" src="https://user-images.githubusercontent.com/21268357/134564293-5d7f1aef-145b-4b85-bc19-ee32c3c462fb.png">
<img width="450" alt="Screen Shot 2021-09-23 at 10 56 20 AM" src="https://user-images.githubusercontent.com/21268357/134564323-d1c8245e-41e2-4461-8ee1-89d37c16e96a.png">


but '700 normal 28pt Arial' (font-weight before style) is not bolded, same as not bolded 'normal 28pt Arial'.
<img width="450" alt="Screen Shot 2021-09-23 at 10 56 49 AM" src="https://user-images.githubusercontent.com/21268357/134563866-87507544-f277-43d9-9636-fee170407c7b.png">
<img width="450" alt="Screen Shot 2021-09-23 at 11 31 08 AM" src="https://user-images.githubusercontent.com/21268357/134563884-0aae881f-459d-48cd-8751-794bcde1b234.png">

Chrome and Firefox don't have this issue since they do some parsing on the style string even interpreting 700 to 'bold' before computing the css so IE11 is just special.