### PR TITLE
React18 compatibility

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -39,22 +39,11 @@ export default class Truncate extends Component {
 
     componentDidMount() {
         const {
-            elements: {
-                text
-            },
-            calcTargetWidth,
             onResize
         } = this;
 
         const canvas = document.createElement('canvas');
         this.canvasContext = canvas.getContext('2d');
-
-        calcTargetWidth(() => {
-            // Node not needed in document tree to read its content
-            if (text) {
-                text.parentNode.removeChild(text);
-            }
-        });
 
         window.addEventListener('resize', onResize);
     }


### PR DESCRIPTION
Hey, all! I'm opening this PR because I came across the errors reported on #153 and the changes on this PR made it work on my React18 + NextJS project. I have no idea why it worked, but I have patched these changes in my application and nothing broke. 

All I know is that I am using it correctly (per docs), along with React 18 + NextJS:
```js
<Truncate lines={width < breakpoints.md ? 4 : 2}>
    A text as string, as you can see, no text formatting, no html, markdown or any formatting language here.
</Truncate>
```

In case anyone is interested in moving this piece of code forward in this library, go ahead! cc @pablosichert